### PR TITLE
Fix Vault file deletion issue when working folder doesn't end in trailing slash.

### DIFF
--- a/Vault2GitCLI/Program.cs
+++ b/Vault2GitCLI/Program.cs
@@ -224,6 +224,12 @@ namespace Vault2Git.CLI
                workingFolder = appSettings.Settings["Convertor.WorkingFolder"].Value;
             }
 
+            // check working folder ends with trailing slash
+            if (workingFolder.Last() != '\\')
+            {
+                workingFolder += '\\';
+            }
+
             if (param.Verbose) 
             {
                Console.WriteLine("WorkingFolder = {0}", workingFolder );


### PR DESCRIPTION
Based on research by @brianacraig: https://github.com/AndreyNikiforov/vault2git/issues/16
